### PR TITLE
explicitly add `xdg-desktop-portal-gtk`

### DIFF
--- a/lutris-appimage.sh
+++ b/lutris-appimage.sh
@@ -120,7 +120,7 @@ echo "Generating AppImage..."
 	--no-history --no-create-timestamp \
 	--compression zstd:level=22 -S26 -B32 \
 	--header uruntime \
-	-i ./AppDir -o Lutris+wine-"$VERSION"-anylinux.dwarfs-"$ARCH".AppImage
+	-i ./AppDir -o Lutris+wine-"$VERSION"-anylinux-"$ARCH".AppImage
 
 zsyncmake *dwarfs*.AppImage -u *dwarfs*.AppImage
 echo "All Done!"

--- a/lutris-appimage.sh
+++ b/lutris-appimage.sh
@@ -20,6 +20,7 @@ run_install() {
 		xdg-utils vulkan-mesa-layers lib32-vulkan-mesa-layers freetype2
 		lib32-freetype2 fuse2 mangohud lib32-mangohud gamescope gamemode
 		lib32-gamemode wine lib32-libglvnd lib32-gnutls xterm python-protobuf
+		xdg-desktop-portal-gtk
 	)
 
 	echo '== checking for updates'


### PR DESCRIPTION
The reason this is needed is because otherwise pacman adds the cosmic portal instead by default, which adds 100 MIB of icons to the appimage. 

This makes the final appimage 525 MiB.